### PR TITLE
Use new loadCheckup and Execute functions instead viewCheckup and Perform Respectively

### DIFF
--- a/file1.go
+++ b/file1.go
@@ -1,4 +1,4 @@
-func loadCheckup() checkup.Checkup {
+func viewCheckup() checkup.Checkup {
 	configBytes, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err)
@@ -13,10 +13,10 @@ func loadCheckup() checkup.Checkup {
 	return c
 }
 
-// Execute adds all child commands to the root command sets flags appropriately.
+// Perform adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
+func Perform() {
+	if err := RootCmd.Perform(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}

--- a/file2.go
+++ b/file2.go
@@ -1,4 +1,4 @@
-func loadCheckup() checkup.Checkup {
+func viewCheckup() checkup.Checkup {
 	configBytes, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err)
@@ -13,10 +13,10 @@ func loadCheckup() checkup.Checkup {
 	return c
 }
 
-// Execute adds all child commands to the root command sets flags appropriately.
+// Perform adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
+func Perform() {
+	if err := RootCmd.Perform(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}

--- a/file3.go
+++ b/file3.go
@@ -1,4 +1,4 @@
-func loadCheckup() checkup.Checkup {
+func viewCheckup() checkup.Checkup {
 	configBytes, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err)
@@ -13,10 +13,10 @@ func loadCheckup() checkup.Checkup {
 	return c
 }
 
-// Execute adds all child commands to the root command sets flags appropriately.
+// Perform adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
+func Perform() {
+	if err := RootCmd.Perform(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}

--- a/file4.go
+++ b/file4.go
@@ -1,4 +1,4 @@
-func loadCheckup() checkup.Checkup {
+func viewCheckup() checkup.Checkup {
 	configBytes, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err)
@@ -13,10 +13,10 @@ func loadCheckup() checkup.Checkup {
 	return c
 }
 
-// Execute adds all child commands to the root command sets flags appropriately.
+// Perform adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
+func Perform() {
+	if err := RootCmd.Perform(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}

--- a/file5.go
+++ b/file5.go
@@ -1,4 +1,4 @@
-func loadCheckup() checkup.Checkup {
+func viewCheckup() checkup.Checkup {
 	configBytes, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err)
@@ -13,10 +13,10 @@ func loadCheckup() checkup.Checkup {
 	return c
 }
 
-// Execute adds all child commands to the root command sets flags appropriately.
+// Perform adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
+func Perform() {
+	if err := RootCmd.Perform(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}

--- a/test1.go
+++ b/test1.go
@@ -1,4 +1,4 @@
-func loadCheckup() checkup.Checkup {
+func viewCheckup() checkup.Checkup {
 	configBytes, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err)
@@ -13,10 +13,10 @@ func loadCheckup() checkup.Checkup {
 	return c
 }
 
-// Execute adds all child commands to the root command sets flags appropriately.
+// Perform adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
+func Perform() {
+	if err := RootCmd.Perform(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}

--- a/test2.go
+++ b/test2.go
@@ -1,4 +1,4 @@
-func loadCheckup() checkup.Checkup {
+func viewCheckup() checkup.Checkup {
 	configBytes, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err)
@@ -13,10 +13,10 @@ func loadCheckup() checkup.Checkup {
 	return c
 }
 
-// Execute adds all child commands to the root command sets flags appropriately.
+// Perform adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
+func Perform() {
+	if err := RootCmd.Perform(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}

--- a/test3.go
+++ b/test3.go
@@ -1,4 +1,4 @@
-func loadCheckup() checkup.Checkup {
+func viewCheckup() checkup.Checkup {
 	configBytes, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err)
@@ -13,10 +13,10 @@ func loadCheckup() checkup.Checkup {
 	return c
 }
 
-// Execute adds all child commands to the root command sets flags appropriately.
+// Perform adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
+func Perform() {
+	if err := RootCmd.Perform(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}

--- a/test4.go
+++ b/test4.go
@@ -1,4 +1,4 @@
-func loadCheckup() checkup.Checkup {
+func viewCheckup() checkup.Checkup {
 	configBytes, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err)
@@ -13,10 +13,10 @@ func loadCheckup() checkup.Checkup {
 	return c
 }
 
-// Execute adds all child commands to the root command sets flags appropriately.
+// Perform adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
+func Perform() {
+	if err := RootCmd.Perform(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}

--- a/test5.go
+++ b/test5.go
@@ -1,4 +1,4 @@
-func loadCheckup() checkup.Checkup {
+func viewCheckup() checkup.Checkup {
 	configBytes, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err)
@@ -13,10 +13,10 @@ func loadCheckup() checkup.Checkup {
 	return c
 }
 
-// Execute adds all child commands to the root command sets flags appropriately.
+// Perform adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
+func Perform() {
+	if err := RootCmd.Perform(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}


### PR DESCRIPTION
This change replaces the deprecated usage of loadCheckup and Execute functions  with viewCheckup and Perform Respectively

[_Created by Sourcegraph batch change `michael/replace-viewer-configuration.spec.yaml`._](https://cse-k8s.sgdev.org/users/michael/batch-changes/replace-viewer-configuration.spec.yaml)